### PR TITLE
DAVAMS-907: Fix the PHP-CS error for variables typed as int

### DIFF
--- a/general/php/82.xml
+++ b/general/php/82.xml
@@ -4,9 +4,9 @@
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
             <property name="declareOnFirstLine" value="true"/>
-            <property name="spacesCountAroundEqualsSign" value="null"/>
-            <property name="linesCountBeforeDeclare" value="null"/>
-            <property name="linesCountAfterDeclare" value="null"/>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
+            <property name="linesCountBeforeDeclare" value="0"/>
+            <property name="linesCountAfterDeclare" value="0"/>
         </properties>
     </rule>
 </ruleset>


### PR DESCRIPTION
This pull request includes a small change to the `general/php/82.xml` file. The change updates the properties for the `SlevomatCodingStandard.TypeHints.DeclareStrictTypes` rule to set specific values for the number of spaces around the equals sign and the number of lines before and after the declare statement.

Changes to `general/php/82.xml`:

* Set `spacesCountAroundEqualsSign` to `0`
* Set `linesCountBeforeDeclare` to `0`
* Set `linesCountAfterDeclare` to `0`